### PR TITLE
test: add ROC plot and confusion matrix tests

### DIFF
--- a/tests/testthat/test-confusion.R
+++ b/tests/testthat/test-confusion.R
@@ -1,0 +1,68 @@
+test_that("confmatr_by_threshold calculates all metrics correctly", {
+  test_vec <- c(0.8, 0.7, 0.6, 0.3, 0.4, 0.2)
+  true_vec <- c(1L, 1L, 0L, 0L, 1L, 0L)
+  res <- xpose.xtras:::confmatr_by_threshold(test_vec, true_vec, threshold = 0.5, pos_val = 1)
+
+  expect_equal(res$threshold, 0.5)                     # evaluated at cutoff 0.5
+  expect_equal(res$P, 3)                                # three positives in truth vector
+  expect_equal(res$N, 3)                                # three negatives in truth vector
+  expect_equal(res$TP, 2)                               # two positives above threshold
+  expect_equal(res$FN, 1)                               # one positive below threshold
+  expect_equal(res$FP, 1)                               # one negative above threshold
+  expect_equal(res$TN, 2)                               # two negatives below threshold
+  expect_equal(res$TPR, 2/3)                            # TP / P
+  expect_equal(res$SEN, 2/3)                            # alias for TPR
+  expect_equal(res$FNR, 1/3)                            # 1 - TPR
+  expect_equal(res$FPR, 1/3)                            # FP / N
+  expect_equal(res$TNR, 2/3)                            # 1 - FPR
+  expect_equal(res$SPC, 2/3)                            # alias for TNR
+  expect_equal(res$BM, 1/3)                             # TPR + TNR - 1
+  expect_equal(res$PT, sqrt(2) - 1)                     # probability threshold formula
+  expect_equal(res$Prevalence, 0.5)                     # P / (P + N)
+  expect_equal(res$PPV, 2/3)                            # TP / (TP + FP)
+  expect_equal(res$NPV, 2/3)                            # TN / (TN + FN)
+  expect_equal(res$LRp, 2)                              # TPR / FPR
+  expect_equal(res$LRn, 1/2)                            # FNR / TNR
+  expect_equal(res$ACC, 4/6)                            # (TP + TN) / (P + N)
+  expect_equal(res$FDR, 1/3)                            # 1 - PPV
+  expect_equal(res$FOR, 1/3)                            # 1 - NPV
+  expect_equal(res$MK, 1/3)                             # PPV + NPV - 1
+  expect_equal(res$deltaP, 1/3)                         # deltaP equals markedness
+  expect_equal(res$DOR, 4)                              # LRp / LRn
+  expect_equal(res$BA, 2/3)                             # (TPR + TNR) / 2
+  expect_equal(res$F_1, 2/3)                            # 2 * PPV * TPR / (PPV + TPR)
+  expect_equal(res$FM, 2/3)                             # sqrt(PPV * TPR)
+  expect_equal(res$MCC, 1/3)                            # Matthews correlation coefficient
+  expect_equal(res$TS, 1/2)                             # TP / (TP + FN + FP)
+  expect_equal(res$CSI, 1/2)                            # critical success index
+})
+
+test_that("confmatr_by_threshold handles multiple thresholds and options", {
+  test_vec <- c(0.8, 0.7, 0.6, 0.3, 0.4, 0.2)
+  true_vec <- c(1L, 1L, 0L, 0L, 1L, 0L)
+
+  res <- xpose.xtras:::confmatr_by_threshold(test_vec, true_vec, threshold = c(0.5, 0.7), pos_val = 1)
+  expect_equal(nrow(res), 2)                             # vector thresholds return one row per cutoff
+
+  res_high <- res[res$threshold == 0.7, ]
+  expect_equal(res_high$TP, 2)                           # two positives exceed 0.7
+  expect_equal(res_high$FP, 0)                           # no negatives exceed 0.7
+  expect_equal(res_high$FPR, 0)                          # FP / N = 0
+  expect_equal(res_high$TNR, 1)                          # all negatives correctly classified
+  expect_equal(res_high$PPV, 1)                          # TP / (TP + FP) with FP=0
+  expect_equal(res_high$NPV, 3/4)                        # TN / (TN + FN)
+  expect_equal(res_high$LRp, Inf)                        # division by zero when FPR = 0
+  expect_equal(res_high$LRn, 1/3)                        # FNR / TNR
+  expect_equal(res_high$BA, 5/6)                         # (TPR + TNR) / 2
+  expect_equal(res_high$F_1, 4/5)                        # 2 * PPV * TPR / (PPV + TPR)
+  expect_equal(res_high$FM, sqrt(2/3))                   # sqrt(PPV * TPR)
+  expect_equal(res_high$MCC, sqrt(1/2))                  # simplified with zero FPR
+  expect_equal(res_high$TS, 2/3)                         # TP / (TP + FN + FP)
+  expect_equal(res_high$CSI, 2/3)                        # critical success index
+
+  res_pref <- xpose.xtras:::confmatr_by_threshold(test_vec, true_vec, threshold = c(0.5, 0.7), pos_val = 1, prepend = "x_")
+  expect_true(all(startsWith(names(res_pref), "x_")))    # prefix applied to all columns
+
+  res_cols <- xpose.xtras:::confmatr_by_threshold(test_vec, true_vec, threshold = 0.5, pos_val = 1, cols = c(threshold, TPR, FPR))
+  expect_equal(names(res_cols), c("threshold", "TPR", "FPR")) # only selected columns returned
+})

--- a/tests/testthat/test-xplot_rocplot.R
+++ b/tests/testthat/test-xplot_rocplot.R
@@ -1,0 +1,92 @@
+test_that("xplot_rocplot adds expected geoms", {
+  data("xpdb_x", package = "xpose.xtras", envir = environment())
+  opt <- xpose::data_opt(post_processing = function(df) {
+    df %>%
+      dplyr::group_by(ID) %>%
+      dplyr::slice_head(n = 2) %>%
+      dplyr::ungroup() %>%
+      dplyr::mutate(prob = dplyr::row_number() / dplyr::n(),
+                    OBS = as.integer(dplyr::row_number() %% 2))
+  })
+  geoms_lists <- function(gg) purrr::map_chr(gg$layers, ~class(.x$geom)[1])
+  base_args <- list(xpdb = xpdb_x, group = "ID", like_col = "prob",
+                    obs_col = "OBS", obs_target = 1, opt = opt, guide = FALSE,
+                    quiet = TRUE)
+  roc_c <- do.call(xplot_rocplot, c(base_args, list(type = "c")))
+  expect_true("GeomPath" %in% geoms_lists(roc_c))
+  roc_p <- do.call(xplot_rocplot, c(base_args, list(type = "p")))
+  expect_true("GeomPoint" %in% geoms_lists(roc_p))
+  roc_t <- do.call(xplot_rocplot, c(base_args, list(type = "t")))
+  expect_true("GeomText" %in% geoms_lists(roc_t))
+  roc_a <- do.call(xplot_rocplot, c(base_args, list(type = "ca")))
+  expect_true("GeomLabel" %in% geoms_lists(roc_a))
+  roc_k <- do.call(xplot_rocplot, c(base_args, list(type = "ck")))
+  expect_true("GeomPoint" %in% geoms_lists(roc_k))
+})
+
+test_that("xplot_rocplot errors when requirements not met", {
+  data("xpdb_x", package = "xpose.xtras", envir = environment())
+  opt <- xpose::data_opt(post_processing = function(df) {
+    df %>%
+      dplyr::group_by(ID) %>%
+      dplyr::slice_head(n = 2) %>%
+      dplyr::ungroup() %>%
+      dplyr::mutate(prob = dplyr::row_number() / dplyr::n(),
+                    OBS = as.integer(dplyr::row_number() %% 2))
+  })
+  expect_error(
+    xplot_rocplot(xpdb_x, type = "p", like_col = "prob", obs_col = "OBS",
+                  obs_target = 1, opt = opt, quiet = TRUE),
+    "group"
+  )
+  expect_error(
+    xplot_rocplot(xpdb_x, type = "a", group = "ID", like_col = "prob",
+                  obs_col = "OBS", obs_target = 1, opt = opt, quiet = TRUE),
+    "Need curve"
+  )
+})
+# New tests for wrapper functions
+
+test_that("roc_plot adds expected geoms", {
+  data("pkpd_m3", package = "xpose.xtras", envir = environment())
+  xpdb <- pkpd_m3 %>%
+    set_var_types(catdv = BLQ, dvprobs = LIKE) %>%
+    set_dv_probs(1, 1 ~ LIKE, .dv_var = BLQ) %>%
+    set_var_levels(1, BLQ = lvl_bin())
+  geoms_lists <- function(gg) purrr::map_chr(gg$layers, ~class(.x$geom)[1])
+  roc <- roc_plot(xpdb, cutpoint = 1, type = "cak", quiet = TRUE, guide = FALSE)
+  expect_true("GeomPath" %in% geoms_lists(roc))
+  expect_true("GeomLabel" %in% geoms_lists(roc))
+  expect_true("GeomPoint" %in% geoms_lists(roc))
+})
+
+test_that("ind_roc returns patchwork of ROC curves", {
+  data("pkpd_m3", package = "xpose.xtras", envir = environment())
+  xpdb <- pkpd_m3 %>%
+    set_var_types(catdv = BLQ, dvprobs = LIKE) %>%
+    set_dv_probs(1, 1 ~ LIKE, .dv_var = BLQ) %>%
+    set_var_levels(1, BLQ = lvl_bin())
+  roc <- ind_roc(xpdb, type = "c", quiet = TRUE)
+  expect_s3_class(roc, "patchwork")
+  first_plot <- roc$patches$plots[[1]]
+  geoms_lists <- function(gg) purrr::map_chr(gg$layers, ~class(.x$geom)[1])
+  expect_true("GeomPath" %in% geoms_lists(first_plot))
+})
+
+test_that("roc_by_mod produces ROC curves per model", {
+  data("pkpd_m3", package = "xpose.xtras", envir = environment())
+  base <- pkpd_m3 %>%
+    set_var_types(catdv = BLQ, dvprobs = LIKE) %>%
+    set_dv_probs(1, 1 ~ LIKE, .dv_var = BLQ) %>%
+    set_var_levels(1, BLQ = lvl_bin())
+  m3_set <- xpose_set(
+    run1 = set_prop(base, run = "run1"),
+    run2 = set_prop(base, run = "run2")
+  )
+  roc <- roc_by_mod(m3_set, type = "c", quiet = TRUE)
+  expect_s3_class(roc, "patchwork")
+  first_plot <- roc$patches$plots[[1]]
+  geoms_lists <- function(gg) purrr::map_chr(gg$layers, ~class(.x$geom)[1])
+  expect_true("GeomPath" %in% geoms_lists(first_plot))
+})
+


### PR DESCRIPTION
## Summary
- add unit tests covering confusion matrix calculations
- test ROC plot outputs and error handling for different type options
- verify roc_plot, ind_roc, and roc_by_mod wrappers integrate with xplot_rocplot

## Testing
- `apt-get update` *(fails: The repository is not signed)*
- `R -q -e "devtools::test()"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c7268394832c9a0dbfa6fe25908e