### PR TITLE
Address additional 0.1.1 failings now on cran

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xpose.xtras
 Title: Extra Functionality for the 'xpose' Package
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     person("John", "Prybylski", , "jprybylski@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-5802-0539"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # xpose.xtras
 
+# xpose.xtras 0.1.2
+* Additional changes relevant to 0.1.1.
+
 # xpose.xtras 0.1.1
 * Minor compatibility changes for nlmixr2 5.0
 

--- a/tests/testthat/test-nlmixr2.R
+++ b/tests/testthat/test-nlmixr2.R
@@ -1,5 +1,5 @@
 test_that("old fit detection works correctly", {
-  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  # Skip if rxode2 < 5.0 due to serialization incompatibility
   skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
@@ -21,7 +21,7 @@ test_that("old fit detection works correctly", {
 })
 
 test_that("backfill throws error for old fits", {
-  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  # Skip if rxode2 < 5.0 due to serialization incompatibility
   skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
@@ -33,7 +33,7 @@ test_that("backfill throws error for old fits", {
 })
 
 test_that("nlmixr2_as_xtra skips backfill for old fits", {
-  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  # Skip if rxode2 < 5.0 due to serialization incompatibility
   skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
@@ -47,7 +47,7 @@ test_that("nlmixr2_as_xtra skips backfill for old fits", {
 })
 
 test_that("nlmixr2 is compatible", {
-  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  # Skip if rxode2 < 5.0 due to serialization incompatibility
   skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")

--- a/tests/testthat/test-nlmixr2.R
+++ b/tests/testthat/test-nlmixr2.R
@@ -1,5 +1,6 @@
 test_that("old fit detection works correctly", {
-  # Skip if rxode2 < 5.0 due to serialization incompatibility
+  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
 
@@ -20,7 +21,8 @@ test_that("old fit detection works correctly", {
 })
 
 test_that("backfill throws error for old fits", {
-  # Skip if rxode2 < 5.0 due to serialization incompatibility
+  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
 
@@ -31,7 +33,8 @@ test_that("backfill throws error for old fits", {
 })
 
 test_that("nlmixr2_as_xtra skips backfill for old fits", {
-  # Skip if rxode2 < 5.0 due to serialization incompatibility
+  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
 
@@ -44,7 +47,8 @@ test_that("nlmixr2_as_xtra skips backfill for old fits", {
 })
 
 test_that("nlmixr2 is compatible", {
-  # Skip if rxode2 < 5.0 due to serialization incompatibility
+  # Skip if rxode2 is not installed or < 5.0 due to serialization incompatibility
+  skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
 
@@ -305,6 +309,7 @@ test_that("nlmixr2 is compatible", {
 
 
 test_that("pure LL fits can be used", {
+  skip_if_not_installed("rxode2")
   skip_if(utils::packageVersion("rxode2") < "5.0",
           "nlmixr2 tests require rxode2 >= 5.0 (incompatible serialization in older versions)")
   skip_if_not_installed("nlmixr2est")


### PR DESCRIPTION
```text
    ══ Failed tests ════════════════════════════════════════════════════════════════
    ── Failure ('test-nlmixr2.R:12:3'): old fit detection works correctly ──────────
    Expected `test_nlmixr2_is_old_fit(xpdb_nlmixr2_old)` to be TRUE.
    Differences:
    `actual`:   FALSE
    `expected`: TRUE 
    
    ── Failure ('test-nlmixr2.R:27:3'): backfill throws error for old fits ─────────
    Expected `backfill_nlmixr2_props(xpdb_nlmixr2_old)` to throw a error.
    
    [ FAIL 2 | WARN 2 | SKIP 9 | PASS 853 ]
    Error:
    ! Test failures.
```