### PR TITLE
Fix CRAN check-time NOTEs and issue #70 (logit CV NA)

### DIFF
--- a/R/xpose_set.R
+++ b/R/xpose_set.R
@@ -766,6 +766,7 @@ NULL
 #' # Remove focus
 #' xpdb_set %>% focus_xpdb(mod2,fix1) %>% focus_xpdb()
 #'
+#' \dontrun{
 #' # Focus function and tidyselect
 #' pheno_set %>%
 #'   focus_xpdb(everything()) %>%
@@ -783,6 +784,7 @@ NULL
 #'   select(run6) %>%
 #'   {.[[1]]$xpdb} %>%
 #'   list_vars()
+#' }
 #'
 #' # Output-generating function applied to a single focused element:
 #' # returns the plot itself, not an xpose_set

--- a/man/focus_xpdb.Rd
+++ b/man/focus_xpdb.Rd
@@ -70,6 +70,7 @@ xpdb_set \%>\% focus_xpdb(mod2,fix1) \%>\% focus_xpdb(mod1, .add=TRUE)
 # Remove focus
 xpdb_set \%>\% focus_xpdb(mod2,fix1) \%>\% focus_xpdb()
 
+\dontrun{
 # Focus function and tidyselect
 pheno_set \%>\%
   focus_xpdb(everything()) \%>\%
@@ -87,6 +88,7 @@ pheno_set \%>\%
   select(run6) \%>\%
   {.[[1]]$xpdb} \%>\%
   list_vars()
+}
 
 # Output-generating function applied to a single focused element:
 # returns the plot itself, not an xpose_set

--- a/tests/testthat/test-fixes.R
+++ b/tests/testthat/test-fixes.R
@@ -494,6 +494,7 @@ test_that("print.xpose_plot() falls back to the ggplot2 <= 3.5.2 label-assignmen
 })
 
 test_that("print.xpose_plot() pagination: multi-page facets are printed", {
+  skip_on_cran() # slow: prints a multi-page paginated plot several times
   data("xpdb_ex_pk", package = "xpose", envir = environment())
   # Restrict to a handful of subjects so a 2x2 grid still spans 2 pages,
   # keeping the (otherwise slow, once-per-page) print() calls below fast.

--- a/tests/testthat/test-modavg_xpdb.R
+++ b/tests/testthat/test-modavg_xpdb.R
@@ -1,4 +1,5 @@
 test_that("model averaging xpdb (modavg_xpdb) works", {
+  skip_on_cran() # slow: computes model averaging across a full multi-model set
 
   #selection
   expect_no_error(

--- a/tests/testthat/test-xplot_pairs.R
+++ b/tests/testthat/test-xplot_pairs.R
@@ -162,6 +162,7 @@ test_that("xplot_pairs falls back to xpose::data_opt() when opt is missing", {
 })
 
 test_that("xplot_pairs accepts gg_theme and xp_theme overrides and renders", {
+  skip_on_cran() # slow: renders a full pairs plot matrix
   opt_xtra <- xpose::data_opt(
     .problem = 1,
     filter = xpose::only_distinct(xpdb_x, 1, NULL, TRUE),
@@ -316,6 +317,7 @@ test_that("print.xp_xtra_plot delegates to NextMethod() for non-ggmatrix objects
 })
 
 test_that("print.xp_xtra_plot exercises the legacy ggplot2 (<= 3.5.2) label branch", {
+  skip_on_cran() # slow: renders a full pairs plot matrix
   # Mirrors the packageVersion() mocking approach used in
   # test-xplot_boxplot.R to reach the pre-3.5.2 ggplot2 code path, which is
   # otherwise unreachable with the ggplot2 version installed in this

--- a/tests/testthat/test-xplot_rocplot.R
+++ b/tests/testthat/test-xplot_rocplot.R
@@ -33,6 +33,7 @@ test_that("xplot_rocplot adds expected geoms", {
 })
 
 test_that("xplot_rocplot defaults/theming/error branches are covered", {
+  skip_on_cran() # slow: renders many ROC plot variants
   opt <- xpose::data_opt(post_processing = function(df) {
     df %>%
       dplyr::group_by(ID) %>%
@@ -127,6 +128,7 @@ test_that("xplot_rocplot errors when requirements not met", {
 # New tests for wrapper functions
 
 test_that("roc_plot adds expected geoms", {
+  skip_on_cran() # slow: renders several ROC plot variants
   xpdb <- pkpd_m3 %>%
     set_var_types(catdv = BLQ, dvprobs = LIKE) %>%
     set_dv_probs(1, 1 ~ LIKE, .dv_var = BLQ) %>%

--- a/tests/testthat/test-xset_plots.R
+++ b/tests/testthat/test-xset_plots.R
@@ -217,6 +217,7 @@ test_that("franken_prop reasonably combines properties", {
 })
 
 test_that("model averaged plots are consistent with manually-implemented", {
+  skip_on_cran() # slow: builds several model-averaged plots across a full set
   # model averaging function is assessed in a separate test script
   # this just ensures plot objects are as expected if manually coded
 
@@ -486,6 +487,7 @@ test_that("waterfall plots produce expected errors", {
 })
 
 test_that("iofv trends can be shown in a boxplot", {
+  skip_on_cran() # slow: renders boxplots across a full multi-model set
   expect_error(
     pheno_set %>%
       iofv_vs_mod(),

--- a/tests/testthat/test-xset_shark.R
+++ b/tests/testthat/test-xset_shark.R
@@ -1,4 +1,5 @@
 test_that("shark_plot works as expected", {
+  skip_on_cran() # slow: renders shark plots across a full multi-model set
   expect_error( # no ofv
     pheno_set %>%
       shark_plot(run6,run11),

--- a/tests/testthat/test-xset_waterfall.R
+++ b/tests/testthat/test-xset_waterfall.R
@@ -1,4 +1,5 @@
 test_that("multiplication works", {
+  skip_on_cran() # slow: renders several waterfall plot variants
   two_mod_set <- xpose_set(pheno_base,pheno_final)
   expect_error(
     xset_waterfall(two_mod_set),

--- a/vignettes/articles/parameter-associations.Rmd
+++ b/vignettes/articles/parameter-associations.Rmd
@@ -39,11 +39,11 @@ pheno_base %>%
 
 `IIVCL` and `IIVV` get a `cv` column; the off-diagonal and fixed-effect rows don't (CV% is only defined for a diagonal random effect acting on a specific structural parameter). This is already the CV% you'd get by hand from a log-normal assumption -- `add_prm_association()` becomes useful the moment that assumption is wrong for a given parameter.
 
-Say `V` was actually fit as logit-normal instead (purely for illustration -- it wasn't, in this model). Declaring that changes only the `cv` column; nothing else about the fit or the table shape changes:
+Say `CL` was actually fit as logit-normal instead (purely for illustration -- it wasn't, in this model). Declaring that changes only the `cv` column; nothing else about the fit or the table shape changes:
 
 ```{r prm_logit}
 pheno_base %>%
-  add_prm_association(V ~ logit(IIVV)) %>%
+  add_prm_association(CL ~ logit(IIVCL)) %>%
   get_prm(quiet = TRUE) %>%
   select(type, name, label, value, cv)
 ```
@@ -70,13 +70,13 @@ Redeclaring an association for the same parameter replaces it; `drop_prm_associa
 
 ```{r prm_drop}
 pheno_base %>%
-  add_prm_association(V ~ logit(IIVV)) %>%
-  drop_prm_association(V) %>%
+  add_prm_association(CL ~ logit(IIVCL)) %>%
+  drop_prm_association(CL) %>%
   get_prm(quiet = TRUE) %>%
   select(name, label, value, cv)
 ```
 
-**One important caveat**: the CV% calculation assumes the *fixed-effect* value is on its natural, untransformed scale. If `V` were actually fitted on the logit scale itself (not just related to a logit-normal omega), the reported `value` would need converting back first -- see [Rescaling with `mutate_prm()`] below.
+**One important caveat**: the CV% calculation assumes the *fixed-effect* value is on its natural, untransformed scale. If `CL` were actually fitted on the logit scale itself (not just related to a logit-normal omega), the reported `value` would need converting back first -- see [Rescaling with `mutate_prm()`] below.
 
 ## Covariate associations and forest plots
 


### PR DESCRIPTION
## Summary

Follow-up to the 0.2.0 release, addressing CRAN's automated-check feedback plus a documentation bug found afterward.

- **CRAN NOTE (r-devel-linux-x86_64-debian-gcc): `focus_xpdb` examples took 5.6s (>5s).** Wrapped the two `backfill_iofv()`-across-`pheno_set` examples in `\dontrun{}` — they were the bulk of the cost, and the remaining basic focus/unfocus + single-plot examples already cover the same API.
- **CRAN NOTE (r-devel-windows-x86_64): overall checktime 13 min > 10 min.** Added `skip_on_cran()` to the 10 slowest individual tests (measured locally), all of which render several/many plots across a full multi-model set rather than testing anything CRAN-check-relevant beyond "it doesn't error" — ~45s of ~105s local suite time. These still run under this project's own CI (`NOT_CRAN=true`).
- **Fixes #70**: the parameter-associations vignette's `V ~ logit(IIVV)` illustration produced a distracting `NA` CV%, since `V`'s fitted value (1.4) is outside logit's required (0,1) domain. Switched to `CL ~ logit(IIVCL)` (CL = 0.0068, safely in-domain), which now shows a real CV%.

## Test plan

- [x] `devtools::check()` — 0 errors, 0 warnings, 0 notes
- [x] `devtools::test()` — full suite passing
- [x] Confirmed via `skip_on_cran()` simulation (unset `NOT_CRAN`) that the targeted tests actually skip
- [x] Confirmed `focus_xpdb`'s example runtime dropped from ~1.26s to ~0.32s (Rd2ex timing)
- [x] Re-rendered the parameter-associations vignette with the real installed package — `CL ~ logit(IIVCL)` now shows CV ≈ 51.3, no NA

🤖 Generated with [Claude Code](https://claude.com/claude-code)