### PR TITLE
Exclude changelog.md from release tarballs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@
 ^renv$
 ^renv\.lock$
 ^VERSION$
+^changelog\.md$


### PR DESCRIPTION
## Summary
`sync-release-metadata.R` writes `changelog.md` to the repo root during `release.yaml`'s run (used for the GitHub release notes body), but it wasn't in `.Rbuildignore` — so it ends up at the top level of every release tarball built afterward, which `R CMD check --as-cran` flags as a "Non-standard file/directory found at top level" NOTE.

Confirmed present in the actual published `xpose.xtras_0.2.2.tar.gz` release asset by downloading it and running `R CMD check --as-cran` directly on it.

**Note on merging this:** `VERSION` is unchanged (still `0.2.2`), so per `sync-release-metadata.R`'s own logic this will be treated as a same-day "refresh" — it moves the existing `v0.2.2` tag to the new commit and re-uploads a rebuilt tarball in place, rather than minting `v0.2.3`.

## Test plan
- [x] Downloaded the real `v0.2.2` release tarball and ran `R CMD check --as-cran` on it directly: confirmed the `changelog.md` NOTE, and confirmed no other real issues (all other flags were local-machine-only, e.g. missing `pdflatex`).
- [x] Verified `changelog.md` isn't tracked/present in the working tree, so this is a pure `.Rbuildignore` addition with no other diff.