### PR TITLE
Cache knitr chunk output across pkgdown.yaml runs

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -56,6 +56,22 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
+      # vignettes/articles/nlmixr2.Rmd's expensive chunks are already
+      # marked cache=TRUE, but that only helps within a single knitr run -
+      # a fresh checkout every job otherwise throws the cache away and
+      # re-fits from scratch every time (observed to take ~8 of this job's
+      # ~13 total build minutes). Persist it across runs via actions/cache
+      # instead; restore-keys falls back to the last cache on any Rmd
+      # edit, since knitr's own per-chunk hash still decides what actually
+      # needs re-running, not just whether the directory exists.
+      - name: Cache knitr chunk cache for vignettes/articles
+        uses: actions/cache@v4
+        with:
+          path: vignettes/articles/*_cache
+          key: pkgdown-knitr-cache-${{ hashFiles('vignettes/articles/*.Rmd') }}
+          restore-keys: |
+            pkgdown-knitr-cache-
+
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}


### PR DESCRIPTION
## Summary
`vignettes/articles/nlmixr2.Rmd`'s expensive chunks are already marked `cache=TRUE`, but every `pkgdown.yaml` job runs from a fresh checkout, so that cache never survives between runs. Measured via the job's own step timings and per-article log timestamps: building that one article alone took ~8 of the job's ~13-minute "Build site" step (~60%), while every other article/reference page takes 10-30s.

This adds an `actions/cache` step to persist the knitr cache directory across runs, keyed on the articles' Rmd content with a `restore-keys` fallback (knitr's own per-chunk hash still governs what actually re-runs, so a stale-but-present cache from a prior key is still useful, not just an exact match).

Doesn't touch anything CRAN-relevant: `vignettes/articles` is already `.Rbuildignore`'d (pkgdown-only content), and `R-CMD-check.yaml`'s own vignette rebuild step was never slow (it doesn't touch this directory). No version bump needed (workflow-only change).

## Test plan
- [x] Confirmed via job step timing (before this change) that "Build site" dominated at ~13min, and `articles/nlmixr2.html` specifically took ~8min per its "Writing" log timestamp, versus 10-30s for every other article.
- [ ] Confirm on the next pkgdown run that a warm cache noticeably reduces "Build site" duration (this PR's own CI run will be a cold cache; the run after merging is the real test).